### PR TITLE
 Implement an SDL2 window/render size based on rc file settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ SDL2_VERSION	= 1
 #	ディレクトリが使用されます。
 #	 ~/ は、QUASI88の起動時にホームディレクトリ（$HOME）に展開されます。
 
-ROMDIR	= ~/quasi88/rom/
+ROMDIR	= ~/.quasi88/rom/
 
 
 # DISK用ディレクトリを設定します
@@ -43,7 +43,7 @@ ROMDIR	= ~/quasi88/rom/
 #	ディレクトリが使用されます。
 #	 ~/ は、QUASI88の起動時にホームディレクトリ（$HOME）に展開されます。
 
-DISKDIR	= ~/quasi88/disk/
+DISKDIR	= ~/.quasi88/disk/
 
 
 # TAPE用ディレクトリを設定します
@@ -52,7 +52,7 @@ DISKDIR	= ~/quasi88/disk/
 #	ディレクトリが使用されます。
 #	 ~/ は、QUASI88の起動時にホームディレクトリ（$HOME）に展開されます。
 
-TAPEDIR	= ~/quasi88/tape/
+TAPEDIR	= ~/.quasi88/tape/
 
 
 # (X11)
@@ -272,7 +272,7 @@ USE_FMGEN	= 1
 #	通常のOS の場合、sdl-config   のままで大丈夫なはずです。
 #	FreeBSD  の場合、sdl12-config などにリネームされていることがあります
 
-SDL_CONFIG	= sdl-config
+SDL_CONFIG	= sdl2-config
 
 
 

--- a/src/SDL2/graph.c
+++ b/src/SDL2/graph.c
@@ -218,8 +218,8 @@ const T_GRAPH_SPEC	*graph_init(void)
 
     // FIXME: identify available video modes (SDL_GetDisplayMode)
 
-    graph_spec.window_max_width = 640;
-    graph_spec.window_max_height = 400;
+    graph_spec.window_max_width = 1280;
+    graph_spec.window_max_height = 800;
     graph_spec.fullscreen_max_width = 0;
     graph_spec.fullscreen_max_height = 0;
     graph_spec.forbid_status         = FALSE;
@@ -370,8 +370,23 @@ printf("@ dont_frameskip  %d\n",    graph_info.dont_frameskip);
 
     return &graph_info;*/
 
-    int sdl_width = 640;
-    int sdl_height = 400;
+    // Set the screen size based on rc file -half|-full|-double
+    // Full screen doesn't work (yet)
+    static int sdl_width;
+    static int sdl_height;
+
+    if (screen_size == SCREEN_SIZE_FULL) {
+       sdl_width = 640;
+       sdl_height = 400;
+    }
+    if (screen_size == SCREEN_SIZE_DOUBLE) {
+       sdl_width = 1280;
+       sdl_height = 800;
+    }
+    if (screen_size == SCREEN_SIZE_HALF) {
+       sdl_width = 320;
+       sdl_height = 200;
+    }
 
     // FIXME HACK just trying to get this damn thing to work
     sdl_window = SDL_CreateWindow("quasi88",

--- a/src/SDL2/graph.c
+++ b/src/SDL2/graph.c
@@ -217,9 +217,12 @@ const T_GRAPH_SPEC	*graph_init(void)
     return &graph_spec;*/
 
     // FIXME: identify available video modes (SDL_GetDisplayMode)
+    // The maximum render size (double) is 1280x800, so
+    // 1296 x 816 (per x16) gives a small border for those who want it
+    // Currently this does nothing to limit -height/-width 
 
-    graph_spec.window_max_width = 1280;
-    graph_spec.window_max_height = 800;
+    graph_spec.window_max_width = 1296;
+    graph_spec.window_max_height = 816;
     graph_spec.fullscreen_max_width = 0;
     graph_spec.fullscreen_max_height = 0;
     graph_spec.forbid_status         = FALSE;
@@ -370,22 +373,46 @@ printf("@ dont_frameskip  %d\n",    graph_info.dont_frameskip);
 
     return &graph_info;*/
 
-    // Set the screen size based on rc file -half|-full|-double
-    // Full screen doesn't work (yet)
+    // If the program (sdl) window size is not defined in the rc file
+    // then set the window size based on rc file's -half|-full|-double.
+    // If this is undefined, then the default is -full
+
     static int sdl_width;
     static int sdl_height;
+    static int render_width;
+    static int render_height;
 
     if (screen_size == SCREEN_SIZE_FULL) {
        sdl_width = 640;
        sdl_height = 400;
+       render_width = 640;
+       render_height= 400;
     }
     if (screen_size == SCREEN_SIZE_DOUBLE) {
        sdl_width = 1280;
        sdl_height = 800;
+       render_width = 1280;
+       render_height = 800;
     }
     if (screen_size == SCREEN_SIZE_HALF) {
        sdl_width = 320;
        sdl_height = 200;
+       render_width = 320;
+       render_height = 200;
+    }
+    // try to avoid an rc defined screen size smaller than the render size
+    if ( WIDTH && HEIGHT ) {
+       sdl_width = WIDTH;
+       sdl_height = HEIGHT;
+
+       if ( sdl_width < render_width ) {
+          sdl_width = render_width;
+          sdl_height = render_height;
+       }
+       if ( sdl_height < render_height ) {
+           sdl_height = render_height;
+           sdl_width = render_width;
+       }
     }
 
     // FIXME HACK just trying to get this damn thing to work


### PR DESCRIPTION
I think that this is likely a better approach to handling the render vs. window size settings. It should honor the rc settings unless you try to create a window smaller than the render size (which crashes). In that case it will force the window to match the render size.

I've also modified the Makefile's settings for default rc data location to match ye olde unix/oss standard practice.

My tests of shown this to be working as-expected, but as I'm barely an amateur I'm certain there are better ways to do this (and possibly bugs). 